### PR TITLE
Lock python version

### DIFF
--- a/chive/README.md
+++ b/chive/README.md
@@ -31,5 +31,5 @@ agent:
 ### run docker
 
 ```
-docker run --user root -it -v $(pwd):/home/jovyan/work -p 8888:8888 -e UB_UID=root -e GRANT_SUDO=yes jupyter/datascience-notebook
+docker run --user root -it -v $(pwd):/home/jovyan/work -p 8888:8888 -e UB_UID=root -e GRANT_SUDO=yes jupyter/datascience-notebook:python-3.7.6
 ```

--- a/chive/README.md
+++ b/chive/README.md
@@ -31,5 +31,5 @@ agent:
 ### run docker
 
 ```
+# use python-3.7.6 image because magnitude does not apply new python version. (2022-06)
 docker run --user root -it -v $(pwd):/home/jovyan/work -p 8888:8888 -e UB_UID=root -e GRANT_SUDO=yes jupyter/datascience-notebook:python-3.7.6
-```


### PR DESCRIPTION
## WHAT

As titled

## WHY

When I executed the notebook, a python import error occurs due to the magnitude library.
The magnitude library only works on python2 and python3.0, python3.7.
